### PR TITLE
adding chronos

### DIFF
--- a/network.js
+++ b/network.js
@@ -18,6 +18,8 @@ Used to set the network: https://chainlist.org/
 62320 Celo Baklava Testnet
 1666700000 Harmony Testnet Shard0
 1666600000 Harmony Mainnet Shard0
+25 Cronos Mainnet Beta
+338 Cronos Testnet
 */
 
 window.web3ChainId = 1;


### PR DESCRIPTION
Adding chronos testnet and mainnet to supported chains. This will also be added to MetaMask if not already added by user.